### PR TITLE
Add `notebook` to keywords

### DIFF
--- a/src/keywords.yaml
+++ b/src/keywords.yaml
@@ -22,6 +22,7 @@ ruleparams:
   - input
   - log
   - message
+  - notebook
   - output
   - params
   - priority


### PR DESCRIPTION
Just added the `notebook` keyword for syntax highlighting.