### PR TITLE
Add `.Snakefile` as supported extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
                     "Snakefile"
                 ],
                 "extensions": [
-                    ".smk"
+                    ".smk",
+                    ".Snakefile"
                 ],
                 "configuration": "./languages/snakemake.json"
             }


### PR DESCRIPTION
Although the documentation says that files with `.Snakemake` extensions are supported they are not included in the package json. This PR address this issue. It's a trivial update, should not be an issue to merge. Works on local.