### PR TITLE
Added missing keywords for highlighting

### DIFF
--- a/languages/snakemake.json
+++ b/languages/snakemake.json
@@ -94,7 +94,7 @@
   ],
   "onEnterRules": [
     {
-      "beforeText": "\\s*(?:(?:rule|subworkflow|checkpoint|async|class|def|elif|except|for|if|while|with)\\s.*|(?:input|output|params|priority|shadow|group|log|benchmark|message|threads|resources|version|run|shell|script|cwl|conda|singularity|wildcard_constraints|wrapper|else|finally|try))\\s*:\\s*(?:#.*)?$",
+      "beforeText": "\\s*(?:(?:rule|subworkflow|checkpoint|async|class|def|elif|except|for|if|while|with)\\s.*|(?:input|output|params|priority|shadow|group|log|benchmark|message|threads|resources|version|run|shell|script|cwl|container|shellcmd|name|norun|conda_env|container_img|is_containerized|env_modules|shadow_depth|docstring|notebook|template_engine|cache|path_modifier|handover|default_target|localrule|conda|singularity|wildcard_constraints|wrapper|else|finally|try))\\s*:\\s*(?:#.*)?$",
       "action": {
         "indent": "indent"
       }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Snakemake Language",
     "icon": "logo-snake.png",
     "description": "Basic syntax, language, and snippet support for Snakefiles (Snakemake workflow definition files)",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "publisher": "snakemake",
     "license": "MIT",
     "repository": {

--- a/src/js/keywords-regex.json
+++ b/src/js/keywords-regex.json
@@ -1,5 +1,5 @@
 {
-    "configs": "configfile|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|container|containerized|pepfile|pepschema",
+    "configs": "configfile|envvars|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|containerized|pepfile|pepschema",
     "rules": "checkpoint|rule|subworkflow",
     "ruleparams": "benchmark|conda|cwl|group|input|log|message|notebook|output|params|priority|resources|run|script|shadow|shell|singularity|threads|version|wildcard_constraints|wrapper|default_target|template_engine|handover|container|containerized",
     "functions": "ancient|directory|expand|pipe|protected|temp|touch|unpack|report"

--- a/src/js/keywords-regex.json
+++ b/src/js/keywords-regex.json
@@ -1,6 +1,6 @@
 {
-    "configs": "configfile|envvars|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|containerized|pepfile|pepschema",
+    "configs": "configfile|envvars|module|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|containerized|pepfile|pepschema",
     "rules": "checkpoint|rule|subworkflow",
-    "ruleparams": "benchmark|conda|cwl|group|input|log|message|notebook|output|params|priority|resources|run|script|shadow|shell|singularity|threads|version|wildcard_constraints|wrapper|default_target|template_engine|handover|container|containerized",
+    "ruleparams": "benchmark|conda|container|cwl|shellcmd|name|norun|conda_env|container_img|is_containerized|env_modules|shadow_depth|docstring|notebook|template_engine|cache|path_modifier|handover|default_target|localrule|group|input|log|message|notebook|output|params|priority|resources|run|script|shadow|shell|singularity|threads|version|wildcard_constraints|wrapper|default_target|template_engine|handover|container|containerized",
     "functions": "ancient|directory|expand|pipe|protected|temp|touch|unpack|report"
 }

--- a/src/keywords.yaml
+++ b/src/keywords.yaml
@@ -9,6 +9,7 @@ configs:
   - snakefile
   - workdir
   - envvars
+  - module
   - containerized
   - pepfile
   - pepschema
@@ -46,6 +47,21 @@ ruleparams:
   - handover
   - container
   - containerized
+  - shellcmd
+  - name
+  - norun
+  - conda_env
+  - container_img
+  - is_containerized
+  - env_modules
+  - shadow_depth
+  - docstring
+  - notebook
+  - template_engine
+  - cache
+  - path_modifier
+  - handover
+  - default_target
   - localrule
   - template_engine
 

--- a/src/keywords.yaml
+++ b/src/keywords.yaml
@@ -8,7 +8,7 @@ configs:
   - ruleorder
   - snakefile
   - workdir
-  - container
+  - envvars
   - containerized
   - pepfile
   - pepschema

--- a/src/yaml/snakemake.language.yaml
+++ b/src/yaml/snakemake.language.yaml
@@ -37,6 +37,6 @@ surroundingPairs:
 
 onEnterRules:
   - beforeText: >-
-    \s*(?:(?:rule|subworkflow|checkpoint|async|class|def|elif|except|for|if|while|with)\s.*|(?:input|output|params|priority|shadow|group|log|benchmark|message|threads|resources|version|run|shell|script|cwl|conda|singularity|container|wildcard_constraints|wrapper|else|finally|try))\s*:\s*(?:#.*)?$
+    \s*(?:(?:rule|subworkflow|checkpoint|async|class|def|elif|except|for|if|while|with)\s.*|(?:input|output|params|priority|shadow|group|log|benchmark|message|threads|resources|version|run|shell|script|cwl|conda|singularity|container|shellcmd|name|norun|conda_env|container_img|is_containerized|env_modules|shadow_depth|docstring|notebook|template_engine|cache|path_modifier|handover|default_target|localrule|wildcard_constraints|wrapper|else|finally|try))\s*:\s*(?:#.*)?$
     action:
       indent: indent

--- a/src/yaml/snakemake.language.yaml
+++ b/src/yaml/snakemake.language.yaml
@@ -37,6 +37,6 @@ surroundingPairs:
 
 onEnterRules:
   - beforeText: >-
-      \s*(?:(?:rule|subworkflow|checkpoint|async|class|def|elif|except|for|if|while|with)\s.*|(?:input|output|params|priority|shadow|group|log|benchmark|message|threads|resources|version|run|shell|script|cwl|conda|singularity|wildcard_constraints|wrapper|else|finally|try))\s*:\s*(?:#.*)?$
+    \s*(?:(?:rule|subworkflow|checkpoint|async|class|def|elif|except|for|if|while|with)\s.*|(?:input|output|params|priority|shadow|group|log|benchmark|message|threads|resources|version|run|shell|script|cwl|conda|singularity|container|wildcard_constraints|wrapper|else|finally|try))\s*:\s*(?:#.*)?$
     action:
       indent: indent

--- a/syntaxes/snakemake.tmLanguage.json
+++ b/syntaxes/snakemake.tmLanguage.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "configs": {
-      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (configfile|envvars|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|pepfile|pepschema) # Keywords\n  : # Ending in colon\n",
+      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (configfile|envvars|module|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|pepfile|pepschema) # Keywords\n  : # Ending in colon\n",
       "captures": {
         "1": {
           "name": "keyword.control.snakemake.config"
@@ -43,7 +43,7 @@
       }
     },
     "ruleparams": {
-      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (benchmark|conda|container|cwl|group|input|log|message|notebook|output|params|priority|resources|run|script|shadow|shell|singularity|threads|version|wildcard_constraints|wrapper|default_target|template_engine|handover) # Keywords\n  : # Ending in colon\n",
+      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (benchmark|conda|container|shellcmd|name|norun|conda_env|container_img|is_containerized|env_modules|shadow_depth|docstring|notebook|template_engine|cache|path_modifier|handover|default_target|localrule|cwl|group|input|log|message|notebook|output|params|priority|resources|run|script|shadow|shell|singularity|threads|version|wildcard_constraints|wrapper|default_target|template_engine|handover) # Keywords\n  : # Ending in colon\n",
       "captures": {
         "1": {
           "name": "keyword.control.snakemake.ruleparam"

--- a/syntaxes/snakemake.tmLanguage.json
+++ b/syntaxes/snakemake.tmLanguage.json
@@ -24,7 +24,7 @@
   ],
   "repository": {
     "configs": {
-      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (configfile|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|pepfile|pepschema) # Keywords\n  : # Ending in colon\n",
+      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (configfile|envvars|include|localrules|onerror|onstart|onsuccess|ruleorder|snakefile|workdir|pepfile|pepschema) # Keywords\n  : # Ending in colon\n",
       "captures": {
         "1": {
           "name": "keyword.control.snakemake.config"
@@ -43,7 +43,7 @@
       }
     },
     "ruleparams": {
-      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (benchmark|conda|cwl|group|input|log|message|notebook|output|params|priority|resources|run|script|shadow|shell|singularity|threads|version|wildcard_constraints|wrapper|default_target|template_engine|handover) # Keywords\n  : # Ending in colon\n",
+      "match": "(?x)\n  ^\\s* # Leading whitespace\n  (benchmark|conda|container|cwl|group|input|log|message|notebook|output|params|priority|resources|run|script|shadow|shell|singularity|threads|version|wildcard_constraints|wrapper|default_target|template_engine|handover) # Keywords\n  : # Ending in colon\n",
       "captures": {
         "1": {
           "name": "keyword.control.snakemake.ruleparam"


### PR DESCRIPTION
A lot of missing keywords for snakemake highlighting. Just added into 0.4.0 token lists.

Addresses some or all of issues #23, #18, #14, #22, #25 