### PR TITLE
fix: exclude the `.snakemake` folder from the watcher and searches

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,14 @@
         "Programming Languages"
     ],
     "contributes": {
+        "configurationDefaults": {
+            "files.watcherExclude": {
+                "**/.snakemake/**": true
+            },
+            "search.exclude": {
+                "**/.snakemake": true
+            }
+        },
         "languages": [
             {
                 "id": "snakemake",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
                 "**/.snakemake/**": true
             },
             "search.exclude": {
-                "**/.snakemake": true
+                "**/.snakemake/**": true
             }
         },
         "languages": [


### PR DESCRIPTION
Adds a few settings to avoid explosive searches (#37).

I believe the API will merge these values without overriding existing ones (see [here](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration)).

[configurationDefaults](https://code.visualstudio.com/api/references/contribution-points#contributes.configurationDefaults) should modify the default configuration without adding user-seen options.

I have omitted `python.analysis.exclude` because any changes will [overwrite existing](https://github.com/microsoft/pylance-release/blob/main/docs/settings/python_analysis_exclude.md) settings. This seems to be unavoidable, until the python extension uses a more sensible approach to this setting.

Word of caution: I am not versed in VSCode extensions!
So please check carefully before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved file watching by excluding certain internal directories, reducing unnecessary background activity.
  - Enhanced search results by automatically omitting specified directories, leading to more relevant results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->