### PR TITLE
fix: make snakemake variable colorful in functions ...

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
 // Hover to view descriptions of existing attributes.
 // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
-	"version": "0.2.0",
+    "version": "0.2.0",
     "configurations": [
         {
             "name": "Extension",

--- a/README.md
+++ b/README.md
@@ -26,59 +26,85 @@ Example taken from [Snakemake documentation](https://snakemake.readthedocs.io/en
 
 <details>
 
-<summary>Keywords and Functions</summary>
+<summary>[Keywords and Functions](src/keywords.yaml)</summary>
 
 - Configurations
-  - configfile
-  - include
-  - localrules
-  - onerror
-  - onstart
-  - onsuccess
-  - ruleorder
-  - snakefile
-  - workdir
-- Rules
-  - checkpoint
-  - rule
-  - subworkflow
+  - these keywords specified in the format `<keyword>: <values>` within a snakefile.
+  - for example:
+    ```snakemake
+    configfile: "config.yaml"
+
+    onsuccess:
+        print("All jobs finished successfully.")
+
+    include: "workflow/report.smk"
+    ```
+
+- Rules and Modules
+  - `rule <rulename>:` defines a rule with its parameters, followed by an indented body
+  - `checkpoint <rulename>:` is a special type of `rule` that allows dynamic determination of workflow steps based on its output.
+  - `module <modulename>:` declares a module repository from which rules can be imported
+  - `subworkflow` is now deprecated
+
 - Rule Parameters
-  - benchmark
-  - conda
-  - cwl
-  - group
-  - input
-  - log
-  - message
-  - output
-  - params
-  - priority
-  - resources
-  - run
-  - script
-  - shadow
-  - shell
-  - singularity
-  - threads
-  - version
-  - wildcard_constraints
-  - wrapper
-- Functions
-  - ancient
-  - directory
-  - expand
-  - pipe
-  - protected
-  - temp
-  - touch
-  - unpack
+  - Used in `rule` and `checkpoint` blocks to define inputs, outputs, and other settings.
+  - You can re- `used rule <rulename> as <newrulename> ... with` different parameters, but you cannot change the way it runs, including:
+    - run
+    - shell
+    - script
+    - notebook
+    - wrapper
+    - template_engine
+    - cwl
+
+- Module Parameters:
+  - Define where and how to import rules when using the `module` directive.
+  - Example:
+    ```snakemake
+    module remote:
+        snakefile: "local.smk"
+        config: {**config, "remote": True}
+        replace_prefix: "local/"
+        prefix: "remote/"
+
+    use rule * from remote as remote_*
+    ```
+
+- Global Variables:
+  - The following classes are available without explicit import from the snakemake module:
+    - `Path`
+    - `WorkflowError`
+  - Important variables used across workflows include:
+    - snakemake
+    - `rules`: reference rules via `rules.<rulename>`
+    - workflow
+    - `checkpoints`: access outputs of checkpoint rules
+    - storage
+    - access
+    - scatter
+    - gather
+
+- Job Parameters:
+  - These parameters are only available during job execution and should be used within `run` or `shell` blocks
+    - input
+    - output
+    - params
+    - wildcards
+    - threads
+    - resources
+    - log
+    - config
+
+- Functions:
+  - Built-in helper functions are available for use without needing to import them
 
 </details>
 
 ## TODO
 
+- [ ] recognize files provided as string after `include:`, `conda`, `snakefile`, and allow quickly jumping to them
+- [ ] add bash-color to docstring in `shell:` block
 - [ ] Indentation rules (really tricky for some reason)
-- [ ] Recognize string substitutions: `"command {input}"`
 - [ ] Recognize wildcard constraints inside string substitutions: `"{sample,[A-Za-z0-9]+}"`
 
 ## Snakemake Support for other Editors

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Example taken from [Snakemake documentation](https://snakemake.readthedocs.io/en
     include: "workflow/report.smk"
     ```
 
-- Rules and Modules
+- [Rules and Modules](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#snakefiles-and-rules)
   - `rule <rulename>:` defines a rule with its parameters, followed by an indented body
-  - `checkpoint <rulename>:` is a special type of `rule` that allows dynamic determination of workflow steps based on its output.
+  - [`checkpoint <rulename>:`] is a special type of `rule` that allows dynamic determination of workflow steps based on its output.
   - `module <modulename>:` declares a module repository from which rules can be imported
   - `subworkflow` is now deprecated
 
@@ -52,12 +52,12 @@ Example taken from [Snakemake documentation](https://snakemake.readthedocs.io/en
     - run
     - shell
     - script
-    - notebook
-    - wrapper
+    - [`notebook`](https://snakemake.readthedocs.io/en/stable/tutorial/interaction_visualization_reporting/tutorial.html#tutorial-interaction-visualization-and-reporting-with-snakemake)
+    - [`wrapper`](https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#wrappers)
     - template_engine
-    - cwl
+    - [`cwl`](https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#common-workflow-language-cwl-support)
 
-- Module Parameters:
+- [Module Parameters](https://snakemake.readthedocs.io/en/stable/snakefiles/modularization.html#modules):
   - Define where and how to import rules when using the `module` directive.
   - Example:
     ```snakemake
@@ -78,11 +78,10 @@ Example taken from [Snakemake documentation](https://snakemake.readthedocs.io/en
     - snakemake
     - `rules`: reference rules via `rules.<rulename>`
     - workflow
-    - `checkpoints`: access outputs of checkpoint rules
-    - storage
-    - access
-    - scatter
-    - gather
+    - `checkpoints`: access outputs of [checkpoint](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#data-dependent-conditional-execution) rules
+    - [`storage`](https://snakemake.readthedocs.io/en/stable/snakefiles/storage.html#storage-support)
+    - [`access`](https://snakemake.readthedocs.io/en/stable/snakefiles/storage.html#access-pattern-annotation)
+    - [`scatter` and `gather`](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#defining-scatter-gather-processes)
 
 - Job Parameters:
   - These parameters are only available during job execution and should be used within `run` or `shell` blocks
@@ -93,10 +92,10 @@ Example taken from [Snakemake documentation](https://snakemake.readthedocs.io/en
     - threads
     - resources
     - log
-    - config
+  - [`config`](https://snakemake.readthedocs.io/en/stable/snakefiles/configuration.html#configuration) is a dict that contains the configuration values and can be accessed everywhere
 
 - Functions:
-  - Built-in helper functions are available for use without needing to import them
+  - Various [built-in helper functions](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#helpers-for-defining-rules) are available for use without needing to import them
 
 </details>
 

--- a/src/yaml/snakemake.syntax.yaml
+++ b/src/yaml/snakemake.syntax.yaml
@@ -4,9 +4,6 @@ scopeName: source.python.snakemake
 fileTypes: [Snakefile, smk]
 
 patterns:
-  - include: "#quotessmall"
-  - include: "#quotesmid"
-  - include: "#quotesbig"
   - include: "#configs"
   - include: "#rules"
   - include: "#modules"
@@ -16,54 +13,87 @@ patterns:
   - include: "#ruleparams"
   - include: "#rulerunparams"
   - include: "#moduleparams"
-  - include: "#classes"
-  - include: "#object"
-  - include: "#ruleargargs"
-  - include: "#ruleargs"
-  - include: "#functions"
+  - include: "#function-call"
+  - include: "#quoteall"
+  - include: "#snakemakenames"
   # - include: '#snakestrings'
   - include: source.python
 
 repository:
+  function-call:
+    name: meta.function-call.snakemake
+    comment: Regular function call of the type "name(args)" in snakemake
+    begin: |
+      (?x)
+        \b(?=
+          ([A-Za-z_][A-Za-z0-9_]*) \s* (\()
+        )
+    end: (\))
+    endCaptures:
+      "1": { name: punctuation.definition.arguments.end.python }
+    patterns:
+      - include: "source.python#special-variables"
+      - include: "source.python#function-name"
+      - include: "#function-arguments"
+
+  function-arguments:
+    begin: (\()
+    end: (?=\))(?!\)\s*\()
+    beginCaptures:
+      "1": { name: punctuation.definition.arguments.begin.python }
+    contentName: meta.function-call.arguments.python
+    patterns:
+      - name: punctuation.separator.arguments.python
+        match: (,)
+      - match: |
+          (?x)
+            (?:(?<=[,(])|^) \s* (\*{1,2})
+        captures:
+          "1": { name: keyword.operator.unpacking.arguments.python }
+      - include: "#snakemakenames"
+      - include: "source.python#lambda-incomplete"
+      - include: "source.python#illegal-names"
+      - match: '\b([[:alpha:]_]\w*)\s*(=)(?!=)'
+        captures:
+          "1": { name: variable.parameter.function-call.python }
+          "2": { name: keyword.operator.assignment.python }
+
+      - name: keyword.operator.assignment.python
+        match: =(?!=)
+      - include: "#snakemakenames"
+      - include: "source.python#expression"
+      - match: \s*(\))\s*(\()
+        captures:
+          "1": { name: punctuation.definition.arguments.end.python }
+          "2": { name: punctuation.definition.arguments.begin.python }
+
+  quoteall:
+    patterns:
+      - include: "#quotessmall"
+      - include: "#quotesmid"
+      - include: "#quotesbig"
   quotessmall:
     begin: \(
     end: \)
     patterns:
-      - include: "#quotessmall"
-      - include: "#quotesmid"
-      - include: "#quotesbig"
-      - include: "#classes"
-      - include: "#object"
-      - include: "#ruleargargs"
-      - include: "#ruleargs"
-      - include: "#functions"
-      - include: source.python
+      - include: "#quoteall"
+      - include: "#snakemakenames"
+      - include: "source.python"
   quotesmid:
     begin: \[
     end: \]
     patterns:
-      - include: "#quotessmall"
-      - include: "#quotesmid"
-      - include: "#quotesbig"
-      - include: "#classes"
-      - include: "#object"
-      - include: "#ruleargargs"
-      - include: "#ruleargs"
-      - include: "#functions"
-      - include: source.python
+      - include: "#quoteall"
+      - include: "#snakemakenames"
+      - include: "source.python"
   quotesbig:
     begin: \{
     end: \}
     patterns:
-      - include: "#quotessmall"
-      - include: "#quotesmid"
-      - include: "#quotesbig"
-      - include: "#classes"
-      - include: "#object"
-      - include: "#ruleargargs"
-      - include: "#ruleargs"
-      - include: "#functions"
-      - include: source.python
+      - include: "#quoteall"
+      - include: "#snakemakenames"
+      - include: "source.python"
+
   configs:
     match: >
       (?x)
@@ -155,10 +185,25 @@ repository:
     captures:
       "1": { name: keyword.control.snakemake.moduleparam }
 
+  snakemakenames:
+    patterns:
+      - include: "#classes"
+      - include: "#rulesrefernce"
+      - include: "#objects"
+      - include: "#ruleargargs"
+      - include: "#ruleargs"
+      - include: "#functions"
+
   classes:
     match: \b({{classes}})\b(?!\s*=)
     captures:
       "1": { name: entity.name.type.class.snakemake }
+
+  rulesrefernce:
+    match: \b({{rules | checkpoints}})\s*\.\s*([A-Za-z_]+)\b(?!\s*=)
+    captures:
+      "1": { name: entity.name.type.class.snakemake }
+      "2": { name: entity.name.variable.snakemake }
 
   objects:
     match: \b({{objects}})\b(?!\s*=)

--- a/src/yaml/snakemake.syntax.yaml
+++ b/src/yaml/snakemake.syntax.yaml
@@ -4,6 +4,8 @@ scopeName: source.python.snakemake
 fileTypes: [Snakefile, smk]
 
 patterns:
+  # - include: "#shellzone"
+  - include: "#snakestrings"
   - include: "#configs"
   - include: "#rules"
   - include: "#modules"
@@ -16,7 +18,6 @@ patterns:
   - include: "#function-call"
   - include: "#quoteall"
   - include: "#snakemakenames"
-  # - include: '#snakestrings'
   - include: source.python
 
 repository:
@@ -26,16 +27,17 @@ repository:
     begin: |
       (?x)
         \b(?=
-          ([A-Za-z_][A-Za-z0-9_]*) \s* (\()
+          ([[:alpha:]_]\w*) \s* (\()
         )
     end: (\))
     endCaptures:
       "1": { name: punctuation.definition.arguments.end.python }
     patterns:
+      - include: "#classes"
+      - include: "#functions"
       - include: "source.python#special-variables"
       - include: "source.python#function-name"
       - include: "#function-arguments"
-
   function-arguments:
     begin: (\()
     end: (?=\))(?!\)\s*\()
@@ -61,6 +63,7 @@ repository:
       - name: keyword.operator.assignment.python
         match: =(?!=)
       - include: "#snakemakenames"
+      - include: "#quoteall"
       - include: "source.python#expression"
       - match: \s*(\))\s*(\()
         captures:
@@ -136,11 +139,11 @@ repository:
       "3": { name: keyword.control.snakemake }
       "4": { name: entity.name.function.snakemake.rule }
       "5": { name: keyword.control.snakemake }
-
   userulesfromas:
     match: >
       (?x)
         \b(use\s+rule)\s+(\w+|\w+\*|\*)\s+(from)\s+(\w+)\s+(as)\s+(\w+|\w+\*)
+        # may end with a "with:"", but that can be caught by other rules
     captures:
       "1": { name: keyword.control.snakemake }
       "2": { name: entity.name.function.snakemake.rule }
@@ -148,11 +151,8 @@ repository:
       "4": { name: entity.name.type.snakemake.rule }
       "5": { name: keyword.control.snakemake }
       "6": { name: entity.name.function.snakemake.rule }
-
   userulesfrom:
-    match: >
-      (?x)
-        \b(use\s+rule)\s+(\w+|\w+\*|\*)\s+(from)\s+(\w+)
+    match: \b(use\s+rule)\s+(\w+|\w+\*|\*)\s+(from)\s+(\w+)
     captures:
       "1": { name: keyword.control.snakemake }
       "2": { name: entity.name.function.snakemake.rule }
@@ -167,7 +167,6 @@ repository:
         : # Ending in colon
     captures:
       "1": { name: keyword.control.snakemake.ruleparam }
-
   rulerunparams:
     match: >
       (?x)
@@ -193,41 +192,64 @@ repository:
       - include: "#ruleargargs"
       - include: "#ruleargs"
       - include: "#functions"
-
   classes:
     match: \b({{classes}})\b(?!\s*=)
     captures:
       "1": { name: entity.name.type.class.snakemake }
-
   rulesrefernce:
-    match: \b({{rules | checkpoints}})\s*\.\s*([A-Za-z_]+)\b(?!\s*=)
+    name: meta.class.snakemake
+    match: \b(rules|checkpoints)\s*\.\s*([A-Za-z_]+)\b(?!\s*=)
     captures:
       "1": { name: entity.name.type.class.snakemake }
       "2": { name: entity.name.variable.snakemake }
-
   objects:
+    name: meta.c
     match: \b({{objects}})\b(?!\s*=)
     captures:
       "1": { name: entity.name.type.class.snakemake }
-
   ruleargargs:
+    name: meta.args.snakemake
     match: \b({{ruleargs}})\s*\.\s*([A-Za-z_]+)\b(?!\s*=)
     captures:
-      "1": { name: entity.name.variable.snakemake }
+      "1": { name: constant.language.snakemake }
       "2": { name: entity.name.variable.snakemake }
-
   ruleargs:
     match: \b({{ruleargs}})\b(?!\s*=)
     captures:
-      "1": { name: entity.name.variable.snakemake }
-
+      "1": { name: constant.language.snakemake }
   functions:
     match: \b({{functions}})\b(?!\s*=)
     captures:
       "1": { name: support.function.builtin.snakemake }
 
-  shell_block:
-    begin: ^\s+shell:\s*\n*\s*\"\"\"
-    end: \"\"\"
+  snakestrings:
+    name: string.quoted.docstring.snakemake
+    begin: \s+(\'\'\'|\"\"\"|\'|\")
+    end: (\1)
+    beginCaptures:
+      "1": { name: punctuation.definition.string.begin.python }
+    endCaptures:
+      "1": { name: punctuation.definition.string.end.python }
     patterns:
-      - include: source.shell
+      - include: "source.python#string-single-bad-brace1-formatting-unicode"
+      - include: "source.python#string-single-bad-brace2-formatting-unicode"
+      - include: "source.python#string-unicode-guts"
+
+  shellzone:
+    name: meta.embedded.shell.snakemake
+    begin: '^(\s+)\s(shell)\s*:'
+    beginCaptures:
+      "2": { name: entity.name.type.class.snakemake }
+    while: ^(?:(\1.*)|)$
+    patterns:
+      - include: "#snakeshellstrings"
+  snakeshellstrings:
+    name: string.quoted.docstring.snakemake.shell
+    begin: \s+(\'\'\'|\"\"\")
+    end: (\1)
+    beginCaptures:
+      "1": { name: punctuation.definition.string.begin.python }
+    endCaptures:
+      "1": { name: punctuation.definition.string.end.python }
+    patterns:
+      - include: "source.shell"

--- a/syntaxes/snakemake.tmLanguage.json
+++ b/syntaxes/snakemake.tmLanguage.json
@@ -7,6 +7,9 @@
   ],
   "patterns": [
     {
+      "include": "#snakestrings"
+    },
+    {
       "include": "#configs"
     },
     {
@@ -50,7 +53,7 @@
     "function-call": {
       "name": "meta.function-call.snakemake",
       "comment": "Regular function call of the type \"name(args)\" in snakemake",
-      "begin": "(?x)\n  \\b(?=\n    ([A-Za-z_][A-Za-z0-9_]*) \\s* (\\()\n  )\n",
+      "begin": "(?x)\n  \\b(?=\n    ([[:alpha:]_]\\w*) \\s* (\\()\n  )\n",
       "end": "(\\))",
       "endCaptures": {
         "1": {
@@ -58,6 +61,12 @@
         }
       },
       "patterns": [
+        {
+          "include": "#classes"
+        },
+        {
+          "include": "#functions"
+        },
         {
           "include": "source.python#special-variables"
         },
@@ -117,6 +126,9 @@
         },
         {
           "include": "#snakemakenames"
+        },
+        {
+          "include": "#quoteall"
         },
         {
           "include": "source.python#expression"
@@ -243,7 +255,7 @@
       }
     },
     "userulesfromas": {
-      "match": "(?x)\n  \\b(use\\s+rule)\\s+(\\w+|\\w+\\*|\\*)\\s+(from)\\s+(\\w+)\\s+(as)\\s+(\\w+|\\w+\\*)\n",
+      "match": "(?x)\n  \\b(use\\s+rule)\\s+(\\w+|\\w+\\*|\\*)\\s+(from)\\s+(\\w+)\\s+(as)\\s+(\\w+|\\w+\\*)\n  # may end with a \"with:\"\", but that can be caught by other rules\n",
       "captures": {
         "1": {
           "name": "keyword.control.snakemake"
@@ -266,7 +278,7 @@
       }
     },
     "userulesfrom": {
-      "match": "(?x)\n  \\b(use\\s+rule)\\s+(\\w+|\\w+\\*|\\*)\\s+(from)\\s+(\\w+)\n",
+      "match": "\\b(use\\s+rule)\\s+(\\w+|\\w+\\*|\\*)\\s+(from)\\s+(\\w+)",
       "captures": {
         "1": {
           "name": "keyword.control.snakemake"
@@ -337,7 +349,8 @@
       }
     },
     "rulesrefernce": {
-      "match": "\\b()\\s*\\.\\s*([A-Za-z_]+)\\b(?!\\s*=)",
+      "name": "meta.class.snakemake",
+      "match": "\\b(rules|checkpoints)\\s*\\.\\s*([A-Za-z_]+)\\b(?!\\s*=)",
       "captures": {
         "1": {
           "name": "entity.name.type.class.snakemake"
@@ -348,6 +361,7 @@
       }
     },
     "objects": {
+      "name": "meta.c",
       "match": "\\b(snakemake|rules|workflow|checkpoints|storage|access|scatter|gather)\\b(?!\\s*=)",
       "captures": {
         "1": {
@@ -356,10 +370,11 @@
       }
     },
     "ruleargargs": {
+      "name": "meta.args.snakemake",
       "match": "\\b(input|output|params|wildcards|threads|resources|log|config)\\s*\\.\\s*([A-Za-z_]+)\\b(?!\\s*=)",
       "captures": {
         "1": {
-          "name": "entity.name.variable.snakemake"
+          "name": "constant.language.snakemake"
         },
         "2": {
           "name": "entity.name.variable.snakemake"
@@ -370,7 +385,7 @@
       "match": "\\b(input|output|params|wildcards|threads|resources|log|config)\\b(?!\\s*=)",
       "captures": {
         "1": {
-          "name": "entity.name.variable.snakemake"
+          "name": "constant.language.snakemake"
         }
       }
     },
@@ -382,9 +397,61 @@
         }
       }
     },
-    "shell_block": {
-      "begin": "^\\s+shell:\\s*\\n*\\s*\\\"\\\"\\\"",
-      "end": "\\\"\\\"\\\"",
+    "snakestrings": {
+      "name": "string.quoted.docstring.snakemake",
+      "begin": "\\s+(\\'\\'\\'|\\\"\\\"\\\"|\\'|\\\")",
+      "end": "(\\1)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.begin.python"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end.python"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.python#string-single-bad-brace1-formatting-unicode"
+        },
+        {
+          "include": "source.python#string-single-bad-brace2-formatting-unicode"
+        },
+        {
+          "include": "source.python#string-unicode-guts"
+        }
+      ]
+    },
+    "shellzone": {
+      "name": "meta.embedded.shell.snakemake",
+      "begin": "^(\\s+)\\s(shell)\\s*:",
+      "beginCaptures": {
+        "2": {
+          "name": "entity.name.type.class.snakemake"
+        }
+      },
+      "while": "^(?:(\\1.*)|)$",
+      "patterns": [
+        {
+          "include": "#snakeshellstrings"
+        }
+      ]
+    },
+    "snakeshellstrings": {
+      "name": "string.quoted.docstring.snakemake.shell",
+      "begin": "\\s+(\\'\\'\\'|\\\"\\\"\\\")",
+      "end": "(\\1)",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.begin.python"
+        }
+      },
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.string.end.python"
+        }
+      },
       "patterns": [
         {
           "include": "source.shell"

--- a/syntaxes/snakemake.tmLanguage.json
+++ b/syntaxes/snakemake.tmLanguage.json
@@ -7,15 +7,6 @@
   ],
   "patterns": [
     {
-      "include": "#quotessmall"
-    },
-    {
-      "include": "#quotesmid"
-    },
-    {
-      "include": "#quotesbig"
-    },
-    {
       "include": "#configs"
     },
     {
@@ -43,28 +34,107 @@
       "include": "#moduleparams"
     },
     {
-      "include": "#classes"
+      "include": "#function-call"
     },
     {
-      "include": "#object"
+      "include": "#quoteall"
     },
     {
-      "include": "#ruleargargs"
-    },
-    {
-      "include": "#ruleargs"
-    },
-    {
-      "include": "#functions"
+      "include": "#snakemakenames"
     },
     {
       "include": "source.python"
     }
   ],
   "repository": {
-    "quotessmall": {
-      "begin": "\\(",
-      "end": "\\)",
+    "function-call": {
+      "name": "meta.function-call.snakemake",
+      "comment": "Regular function call of the type \"name(args)\" in snakemake",
+      "begin": "(?x)\n  \\b(?=\n    ([A-Za-z_][A-Za-z0-9_]*) \\s* (\\()\n  )\n",
+      "end": "(\\))",
+      "endCaptures": {
+        "1": {
+          "name": "punctuation.definition.arguments.end.python"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.python#special-variables"
+        },
+        {
+          "include": "source.python#function-name"
+        },
+        {
+          "include": "#function-arguments"
+        }
+      ]
+    },
+    "function-arguments": {
+      "begin": "(\\()",
+      "end": "(?=\\))(?!\\)\\s*\\()",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.arguments.begin.python"
+        }
+      },
+      "contentName": "meta.function-call.arguments.python",
+      "patterns": [
+        {
+          "name": "punctuation.separator.arguments.python",
+          "match": "(,)"
+        },
+        {
+          "match": "(?x)\n  (?:(?<=[,(])|^) \\s* (\\*{1,2})\n",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.unpacking.arguments.python"
+            }
+          }
+        },
+        {
+          "include": "#snakemakenames"
+        },
+        {
+          "include": "source.python#lambda-incomplete"
+        },
+        {
+          "include": "source.python#illegal-names"
+        },
+        {
+          "match": "\\b([[:alpha:]_]\\w*)\\s*(=)(?!=)",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.function-call.python"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.python"
+            }
+          }
+        },
+        {
+          "name": "keyword.operator.assignment.python",
+          "match": "=(?!=)"
+        },
+        {
+          "include": "#snakemakenames"
+        },
+        {
+          "include": "source.python#expression"
+        },
+        {
+          "match": "\\s*(\\))\\s*(\\()",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.arguments.end.python"
+            },
+            "2": {
+              "name": "punctuation.definition.arguments.begin.python"
+            }
+          }
+        }
+      ]
+    },
+    "quoteall": {
       "patterns": [
         {
           "include": "#quotessmall"
@@ -74,21 +144,18 @@
         },
         {
           "include": "#quotesbig"
+        }
+      ]
+    },
+    "quotessmall": {
+      "begin": "\\(",
+      "end": "\\)",
+      "patterns": [
+        {
+          "include": "#quoteall"
         },
         {
-          "include": "#classes"
-        },
-        {
-          "include": "#object"
-        },
-        {
-          "include": "#ruleargargs"
-        },
-        {
-          "include": "#ruleargs"
-        },
-        {
-          "include": "#functions"
+          "include": "#snakemakenames"
         },
         {
           "include": "source.python"
@@ -100,28 +167,10 @@
       "end": "\\]",
       "patterns": [
         {
-          "include": "#quotessmall"
+          "include": "#quoteall"
         },
         {
-          "include": "#quotesmid"
-        },
-        {
-          "include": "#quotesbig"
-        },
-        {
-          "include": "#classes"
-        },
-        {
-          "include": "#object"
-        },
-        {
-          "include": "#ruleargargs"
-        },
-        {
-          "include": "#ruleargs"
-        },
-        {
-          "include": "#functions"
+          "include": "#snakemakenames"
         },
         {
           "include": "source.python"
@@ -133,28 +182,10 @@
       "end": "\\}",
       "patterns": [
         {
-          "include": "#quotessmall"
+          "include": "#quoteall"
         },
         {
-          "include": "#quotesmid"
-        },
-        {
-          "include": "#quotesbig"
-        },
-        {
-          "include": "#classes"
-        },
-        {
-          "include": "#object"
-        },
-        {
-          "include": "#ruleargargs"
-        },
-        {
-          "include": "#ruleargs"
-        },
-        {
-          "include": "#functions"
+          "include": "#snakemakenames"
         },
         {
           "include": "source.python"
@@ -275,11 +306,44 @@
         }
       }
     },
+    "snakemakenames": {
+      "patterns": [
+        {
+          "include": "#classes"
+        },
+        {
+          "include": "#rulesrefernce"
+        },
+        {
+          "include": "#objects"
+        },
+        {
+          "include": "#ruleargargs"
+        },
+        {
+          "include": "#ruleargs"
+        },
+        {
+          "include": "#functions"
+        }
+      ]
+    },
     "classes": {
       "match": "\\b(Path|WorkflowError)\\b(?!\\s*=)",
       "captures": {
         "1": {
           "name": "entity.name.type.class.snakemake"
+        }
+      }
+    },
+    "rulesrefernce": {
+      "match": "\\b()\\s*\\.\\s*([A-Za-z_]+)\\b(?!\\s*=)",
+      "captures": {
+        "1": {
+          "name": "entity.name.type.class.snakemake"
+        },
+        "2": {
+          "name": "entity.name.variable.snakemake"
         }
       }
     },


### PR DESCRIPTION
... and also make string without assignment (so called 'docstring' in python syntaxes) as colorful as other strings.

The README is updated as well and more descriptions about the keywords are added

![image](https://github.com/user-attachments/assets/708e0ddd-cb71-43ae-aa8a-f72b86e3094a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated and expanded the user guide with clearer explanations and examples for Snakemake keywords, rules, parameters, and usage sections.

- **New Features**
  - Enhanced syntax highlighting for Snakemake scripts, offering more accurate visual representation of function calls, arguments, string formats, and embedded shell commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->