### PR TITLE
feat: set file icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 *.vsix
+dist
+languages
+snippets
+syntaxes

--- a/package.json
+++ b/package.json
@@ -43,7 +43,11 @@
                     ".smk",
                     ".Snakefile"
                 ],
-                "configuration": "./languages/snakemake.json"
+                "configuration": "./languages/snakemake.json",
+                "icon": {
+                    "light": "./logo-snake.png",
+                    "dark": "./logo-snake.png"
+                }
             }
         ],
         "grammars": [


### PR DESCRIPTION
Snakemake files are currently displayed with the generic file icon.
This PR registers a language icon so they use the Snakemake logo instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual language icons for Snakemake extension support with dedicated light and dark theme variants

* **Chores**
  * Updated project build configuration with new ignore patterns for compiled distributions, language resources, code snippets, and syntax files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->